### PR TITLE
properly handle errors in async/await pattern

### DIFF
--- a/src/__mocks__/hapi.ts
+++ b/src/__mocks__/hapi.ts
@@ -1,0 +1,19 @@
+let mockHapi = require.requireActual('hapi')
+
+mockHapi.Server = () => {
+    return {
+        start: async () => {
+            try {
+                throw 'error'
+            } catch {
+                throw 'error'
+            }
+        },
+        route: () => {},
+        events: {
+            on: () => {},
+        },
+    }
+}
+
+module.exports = mockHapi

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 import * as Server from './lib/server'
 import * as Hoek from 'hoek'
 
-Server.init((err, server) => {
-    Hoek.assert(!err, err)
-    console.log('--------------------------------------------------------------------------------');
-    console.log('Hapi:\n', server.info.uri);
-    console.log('Environment:\n', server.settings.app.environment);
-    console.log('--------------------------------------------------------------------------------');
-})
+try {
+    Server.init()
+} catch (error) {
+    Hoek.assert(!error, error)
+}

--- a/src/lib/__tests__/server.ts
+++ b/src/lib/__tests__/server.ts
@@ -1,15 +1,9 @@
 import * as Server from '../server'
 
+jest.unmock('hapi')
+
 describe('test server', () => {
-    afterAll(async (done) => {
-        Server.server.events.on('stop', () => {
-            done()
-        })
-
-        Server.server.stop()
-    })
-
-    test('test endpoint', async () => {
+    test('test endpoint /{*name}', async () => {
         const options = {
             method: 'GET',
             url: '/Jon',
@@ -20,21 +14,19 @@ describe('test server', () => {
 
         expect(response.statusCode).toBe(200)
         expect(payload).toBe('Hello, Jon')
-
-        await Server.server.stop()
     })
 
-    test('start and stop server', async () => {
-        await Server.init(() => {})
-        await Server.server.stop()
-    })
+    test('start and stop server using our init method', async () => {
+        try {
+            await Server.init()
+        } catch(error) {
+            expect(error).toBeNull()
+        }
 
-    test('error in start up', async () => {
-        Server.server.start()
-
-        await Server.init(async (err, server) => {
-            expect(err.message).toBe('Cannot start server while it is in initializing phase')
-            Server.server.stop()
-        })
+        try {
+            await Server.server.stop()
+        } catch(error) {
+            expect(error).toBeNull()
+        }
     })
 })

--- a/src/lib/__tests__/server_mocked.ts
+++ b/src/lib/__tests__/server_mocked.ts
@@ -1,0 +1,13 @@
+import * as Server from '../server'
+
+jest.mock('hapi')
+
+describe('test server', () => {
+    test('error in start up', async () => {
+        try {
+            await Server.init()
+        } catch(error) {
+            expect(error.message).toBe('error')
+        }
+    })
+})

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -24,12 +24,15 @@ server.route({
     }
 })
 
-const init = async (callback) => {
+const init = async () => {
     try {
         await server.start()
-        return callback(null, server)
+        console.log('--------------------------------------------------------------------------------');
+        console.log('Hapi:\n', server.info.uri);
+        console.log('Environment:\n', server.settings.app.environment);
+        console.log('--------------------------------------------------------------------------------');
     } catch (err) {
-        return callback(err)
+        throw new Error(err)
     }
 }
 


### PR DESCRIPTION
remove callbacks from init
refactor root index.ts into try…catch block
write a mock for hapi
separate mocked server.ts test from others
remove unnecessary code from unmocked server.ts tests